### PR TITLE
Configurable processors count and index pool size

### DIFF
--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -28,3 +28,6 @@ discovery:
   zen:
     ping.unicast.hosts: ${DISCOVERY_SERVICE}
     minimum_master_nodes: ${NUMBER_OF_MASTERS}
+
+thread_pool.index.queue_size: ${THREAD_POOL_INDEX_QUEUE_SIZE}
+processors: ${PROCESSORS}


### PR DESCRIPTION
- Default value for `processors` is number of cores which in Kubernetes
  environemnt means of cores for the host machine which is usually very
  different from pod limits which then results in thread contention
- Default value for `thread_pool.index.queue_size` is 200 which
  sometimes is just not enough